### PR TITLE
Adding animations to page transitions between metadata display pages

### DIFF
--- a/src/renderer/components/configure-recording-set-page/configure-recording-set.tsx
+++ b/src/renderer/components/configure-recording-set-page/configure-recording-set.tsx
@@ -27,10 +27,9 @@ import AddRecordingSetButton from './add-recording-set-button';
 import CreatedRecordingSetList from './created-recording-set-list';
 import SetMetaConfiguration from './set-meta-configuration';
 import SetRecordingListConfiguration from './set-recording-list-configuration';
-import { BuiltInRecordingList } from './types';
+import { BuiltInRecordingList, RecordingPageState } from './types';
 
 import './show-details.scss';
-import { RecordingPageState } from '.';
 
 interface ProjectFile extends RecordingProject {
   name: string;

--- a/src/renderer/components/configure-recording-set-page/configure-recording-set.tsx
+++ b/src/renderer/components/configure-recording-set-page/configure-recording-set.tsx
@@ -1,0 +1,295 @@
+import log from 'electron-log';
+import React, { FC, Fragment, MouseEventHandler, useContext, useEffect, useState } from 'react';
+import Col from 'react-bootstrap/Col';
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import { useTranslation } from 'react-i18next';
+import CSSTransition from 'react-transition-group/CSSTransition';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
+
+import { RecordingProjectContext } from '../../contexts';
+import { PROJECT_CONFIG_FILENAME } from '../../env-and-consts';
+import { Consumer, RecordingProject, RecordingSet, ScaleKey, SupportedOctave } from '../../types';
+import {
+  checkFileExistence,
+  deleteFolder,
+  ensureFolderExists,
+  getLSKey,
+  join,
+  naiveSerialize,
+  readFile,
+  writeFile,
+} from '../../utils';
+import BackButton from '../back-button';
+import NextButton from '../next-button';
+
+import AddRecordingSetButton from './add-recording-set-button';
+import CreatedRecordingSetList from './created-recording-set-list';
+import SetMetaConfiguration from './set-meta-configuration';
+import SetRecordingListConfiguration from './set-recording-list-configuration';
+import { BuiltInRecordingList } from './types';
+
+import './show-details.scss';
+import { RecordingPageState } from '.';
+
+interface ProjectFile extends RecordingProject {
+  name: string;
+  recordingSets: RecordingSet[];
+}
+
+const DUMMY_PROJECT_FILE = {
+  name: '',
+  rootPath: '',
+  recordingSets: [],
+};
+
+const BUILT_IN_RECORDING_LISTS: BuiltInRecordingList[] = [
+  'デルタ式英語リストver5 (Delta English Ver. 5)',
+  'Z式CVVC-Normal (Z Chinese CVVC - Normal)',
+];
+
+const ConfigureRecordingSet: FC<{
+  onNext: MouseEventHandler<HTMLElement>;
+  onBack: MouseEventHandler<HTMLElement>;
+  onSetSelected: Consumer<RecordingSet>;
+  setRecordingSetState: Consumer<RecordingPageState>;
+  setPrevRecordingSetState: Consumer<RecordingPageState>;
+  prevState: RecordingPageState;
+}> = ({ onNext, onBack, onSetSelected, setRecordingSetState, setPrevRecordingSetState, prevState }) => {
+  const { t } = useTranslation();
+  const { recordingProject } = useContext(RecordingProjectContext);
+  const [projectFile = DUMMY_PROJECT_FILE, setProjectFile] = useLocalStorage<ProjectFile>(
+    getLSKey('ConfigureRecordingSetPage', 'projectFile'),
+    DUMMY_PROJECT_FILE,
+  );
+  const [recordingSets = [], setRecordingSets] = useLocalStorage<RecordingSet[]>(
+    getLSKey('ConfigureRecordingSetPage', 'recordingSets'),
+    [],
+  );
+  const [showingDetails = false, setShowingDetails] = useLocalStorage(
+    getLSKey('ConfigureRecordingSetPage', 'showingDetails'),
+    false,
+  );
+  const [canWrite, setCanWrite] = useState(false);
+
+  useEffect(() => {
+    if (recordingProject) {
+      (async (): Promise<void> => {
+        const { rootPath } = recordingProject;
+        const configFilePath = join(rootPath, PROJECT_CONFIG_FILENAME);
+
+        const fileExistence = await checkFileExistence(configFilePath);
+        if (!fileExistence) {
+          setProjectFile(DUMMY_PROJECT_FILE);
+        } else if (fileExistence === 'folder') {
+          throw new Error(`Config file cannot be read because it is a directory: ${configFilePath}`);
+        } else {
+          // TODO Write a loader
+          const projectState = JSON.parse(await readFile(configFilePath)) as ProjectFile;
+          setProjectFile(projectState);
+          setRecordingSets(projectState.recordingSets);
+        }
+        setCanWrite(true);
+      })();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [naiveSerialize(recordingProject), setProjectFile, setRecordingSets]);
+
+  useEffect(() => {
+    if (projectFile.recordingSets.length) {
+      // FIXME Need real loading
+      setRecordingSets(projectFile.recordingSets);
+    }
+  }, [projectFile, setRecordingSets]);
+
+  const [chosenKey = 'C', setChosenKey] = useLocalStorage<ScaleKey>(
+    getLSKey('ConfigureRecordingSetPage', 'chosenKey'),
+    'C',
+  );
+  const [chosenOctave = 3, setChosenOctave] = useLocalStorage<SupportedOctave>(
+    getLSKey('ConfigureRecordingSetPage', 'chosenOctave'),
+    3,
+  );
+  const [chosenName = '', setChosenName] = useLocalStorage(getLSKey('ConfigureRecordingSetPage', 'chosenName'), '');
+  const [chosenBuiltInList = '', rawSetChosenBuiltInList] = useLocalStorage(
+    getLSKey('ConfigureRecordingSetPage', 'chosenBuiltInList'),
+    '',
+  );
+  const [chosenCustomListPath = '', rawSetChosenCustomListPath] = useLocalStorage(
+    getLSKey('ConfigureRecordingSetPage', 'chosenCustomListPath'),
+    '',
+  );
+  const setChosenBuiltInList = (name: string): void => {
+    rawSetChosenBuiltInList(name);
+    if (name) {
+      rawSetChosenCustomListPath('');
+    }
+  };
+  const setChosenCustomListPath = (filePath: string): void => {
+    rawSetChosenCustomListPath(filePath);
+    if (filePath) {
+      rawSetChosenBuiltInList('');
+    }
+  };
+
+  const addRecordingSet = async (newRecordingSet: RecordingSet): Promise<void> => {
+    if (recordingProject) {
+      const recordingSetPath = join(recordingProject.rootPath, newRecordingSet.name);
+      await ensureFolderExists(recordingSetPath);
+      setRecordingSets([...recordingSets, newRecordingSet]);
+    }
+  };
+
+  const [selectedRecordingSetIndex = -1, setSelectedRecordingSetIndex] = useLocalStorage<number>(
+    getLSKey('ConfigureRecordingSetPage', 'selectedRecordingSetIndex'),
+    -1,
+  );
+
+  const removeRecordingSet = async (setToDelete: RecordingSet): Promise<void> => {
+    const willDelete = confirm(`Are you sure you want to delete ${setToDelete.name}?`);
+    if (willDelete) {
+      const newSets = recordingSets.filter((x) => x !== setToDelete);
+      setRecordingSets(newSets);
+
+      if (recordingSets[selectedRecordingSetIndex] === setToDelete) {
+        setSelectedRecordingSetIndex(-1);
+      }
+
+      if (recordingProject) {
+        const willDeleteFiles = confirm(`Are you sure you want to delete the files also?`);
+        if (willDeleteFiles) {
+          const recordingSetPath = join(recordingProject.rootPath, setToDelete.name);
+          return deleteFolder(recordingSetPath);
+        }
+      }
+    }
+  };
+
+  const clearTemporaryItemsOnBack: typeof onBack = (e) => {
+    setCanWrite(false);
+    setChosenKey('C');
+    setChosenOctave(3);
+    setChosenName('');
+    rawSetChosenBuiltInList('');
+    rawSetChosenCustomListPath('');
+    setSelectedRecordingSetIndex(-1);
+    setProjectFile(DUMMY_PROJECT_FILE);
+    setShowingDetails(false);
+    setImmediate(() => onBack(e));
+  };
+
+  useEffect(() => {
+    onSetSelected(recordingSets[selectedRecordingSetIndex]);
+    // We have to ignore onSetSelected because it's new every time
+    // eslint-disable-next-line
+  }, [recordingSets, selectedRecordingSetIndex]);
+
+  useEffect(() => {
+    if (canWrite && recordingProject) {
+      const currentProjectState: Partial<ProjectFile> = {
+        name: recordingProject.name,
+        recordingSets,
+      };
+      writeFile(
+        join(recordingProject.rootPath, PROJECT_CONFIG_FILENAME),
+        JSON.stringify(currentProjectState, null, 2),
+      ).catch(log.error);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [naiveSerialize(recordingProject), naiveSerialize(recordingSets)]);
+
+  const transitionProps = {
+    in: true,
+    appear: true,
+    timeout: 3000,
+    classNames: prevState == 'external' ? '' : 'config-rec-set',
+  };
+
+  return (
+    <Fragment>
+      <CSSTransition {...transitionProps}>
+        <BackButton onBack={clearTemporaryItemsOnBack} />
+      </CSSTransition>
+      <CSSTransition {...transitionProps}>
+        <Container style={{ height: '100%' }} className={'d-flex justify-content-center align-items-center'}>
+          <Col>
+            <Row>
+              <SetMetaConfiguration
+                chosenKey={chosenKey}
+                setChosenKey={setChosenKey}
+                chosenOctave={chosenOctave}
+                setChosenOctave={setChosenOctave}
+                chosenName={chosenName}
+                setChosenName={setChosenName}
+              />
+            </Row>
+            <Row>
+              <SetRecordingListConfiguration
+                builtInLists={BUILT_IN_RECORDING_LISTS}
+                chosenBuiltInList={chosenBuiltInList}
+                setChosenBuiltInList={setChosenBuiltInList}
+                chosenCustomListPath={chosenCustomListPath}
+                setChosenCustomListPath={setChosenCustomListPath}
+              />
+              <Col xs={'auto'} sm={'auto'} md={'auto'} lg={'auto'} xl={'auto'}>
+                <AddRecordingSetButton
+                  chosenKey={chosenKey}
+                  chosenOctave={chosenOctave}
+                  chosenName={chosenName}
+                  chosenBuiltInList={chosenBuiltInList}
+                  chosenCustomListPath={chosenCustomListPath}
+                  existingSets={recordingSets}
+                  addRecordingSet={addRecordingSet}
+                />
+              </Col>
+            </Row>
+            <Row style={{ marginTop: '1rem' }}>
+              <Col xs={2} sm={2} md={2} lg={2} xl={2}>
+                {t('Created')}
+              </Col>
+              <Col xs={'auto'} sm={8} md={8} lg={8} xl={8}>
+                <CreatedRecordingSetList
+                  recordingSets={recordingSets}
+                  removeRecordingSet={removeRecordingSet}
+                  selectedRecordingSetIndex={selectedRecordingSetIndex}
+                  setSelectedRecordingSetIndex={setSelectedRecordingSetIndex}
+                  style={{
+                    maxHeight: '14rem',
+                    overflowY: 'scroll',
+                  }}
+                />
+              </Col>
+              <Col />
+            </Row>
+          </Col>
+        </Container>
+      </CSSTransition>
+      <CSSTransition {...transitionProps}>
+        <NextButton
+          text={t('Start')}
+          onClick={(event: React.MouseEvent<HTMLElement, MouseEvent>): void => {
+            setPrevRecordingSetState('external');
+            onNext(event);
+          }}
+          disabled={selectedRecordingSetIndex < 0}
+        />
+      </CSSTransition>
+      <CSSTransition {...transitionProps}>
+        <div
+          // position={'bottom-center'}
+          style={{ bottom: undefined, display: 'hidden' }}
+          className={`show-details ${
+            showingDetails ? 'move-up-in-down-out-start-in' : 'move-up-in-down-out-start-out'
+          }`}
+          onClick={(): void => {
+            setRecordingSetState(prevState == 'external' ? 'list-preview' : prevState);
+            setPrevRecordingSetState('home');
+          }}>
+          {t('Show Details')}
+        </div>
+      </CSSTransition>
+    </Fragment>
+  );
+};
+
+export default ConfigureRecordingSet;

--- a/src/renderer/components/configure-recording-set-page/configure-recording-set.tsx
+++ b/src/renderer/components/configure-recording-set-page/configure-recording-set.tsx
@@ -27,9 +27,10 @@ import AddRecordingSetButton from './add-recording-set-button';
 import CreatedRecordingSetList from './created-recording-set-list';
 import SetMetaConfiguration from './set-meta-configuration';
 import SetRecordingListConfiguration from './set-recording-list-configuration';
-import { BuiltInRecordingList, RecordingPageState } from './types';
+import { BuiltInRecordingList } from './types';
 
 import './show-details.scss';
+import { RecordingPageState } from '.';
 
 interface ProjectFile extends RecordingProject {
   name: string;

--- a/src/renderer/components/configure-recording-set-page/configure-recording-set.tsx
+++ b/src/renderer/components/configure-recording-set-page/configure-recording-set.tsx
@@ -5,7 +5,6 @@ import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import { useTranslation } from 'react-i18next';
 import CSSTransition from 'react-transition-group/CSSTransition';
-import { usePrevious } from 'react-use';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 
 import { RecordingProjectContext } from '../../contexts';
@@ -49,7 +48,7 @@ const BUILT_IN_RECORDING_LISTS: BuiltInRecordingList[] = [
   'Z式CVVC-Normal (Z Chinese CVVC - Normal)',
 ];
 
-const ConfigureRecordingSet: FC<{
+export const ConfigureRecordingSet: FC<{
   onNext: MouseEventHandler<HTMLElement>;
   onBack: MouseEventHandler<HTMLElement>;
   onSetSelected: Consumer<RecordingSet>;
@@ -288,7 +287,6 @@ const ConfigureRecordingSet: FC<{
           }`}
           onClick={(): void => {
             setRecordingSetState(prevState == 'home' || prevState == 'external' ? 'list-preview' : prevState);
-            console.log('clicked');
           }}>
           {t('Show Details')}
         </div>
@@ -296,5 +294,3 @@ const ConfigureRecordingSet: FC<{
     </Fragment>
   );
 };
-
-export default ConfigureRecordingSet;

--- a/src/renderer/components/configure-recording-set-page/configure-recording-set.tsx
+++ b/src/renderer/components/configure-recording-set-page/configure-recording-set.tsx
@@ -5,6 +5,7 @@ import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import { useTranslation } from 'react-i18next';
 import CSSTransition from 'react-transition-group/CSSTransition';
+import { usePrevious } from 'react-use';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 
 import { RecordingProjectContext } from '../../contexts';
@@ -53,9 +54,9 @@ const ConfigureRecordingSet: FC<{
   onBack: MouseEventHandler<HTMLElement>;
   onSetSelected: Consumer<RecordingSet>;
   setRecordingSetState: Consumer<RecordingPageState>;
-  setPrevRecordingSetState: Consumer<RecordingPageState>;
   prevState: RecordingPageState;
-}> = ({ onNext, onBack, onSetSelected, setRecordingSetState, setPrevRecordingSetState, prevState }) => {
+  currState: RecordingPageState;
+}> = ({ onNext, onBack, onSetSelected, setRecordingSetState, prevState, currState }) => {
   const { t } = useTranslation();
   const { recordingProject } = useContext(RecordingProjectContext);
   const [projectFile = DUMMY_PROJECT_FILE, setProjectFile] = useLocalStorage<ProjectFile>(
@@ -197,18 +198,22 @@ const ConfigureRecordingSet: FC<{
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [naiveSerialize(recordingProject), naiveSerialize(recordingSets)]);
-
   const transitionProps = {
     in: true,
     appear: true,
     timeout: 3000,
-    classNames: prevState == 'external' ? '' : 'config-rec-set',
+    classNames: currState == 'external' ? '' : 'config-rec-set',
   };
 
   return (
     <Fragment>
       <CSSTransition {...transitionProps}>
-        <BackButton onBack={clearTemporaryItemsOnBack} />
+        <BackButton
+          onBack={(event: React.MouseEvent<HTMLElement, MouseEvent>): void => {
+            setRecordingSetState('external');
+            clearTemporaryItemsOnBack(event);
+          }}
+        />
       </CSSTransition>
       <CSSTransition {...transitionProps}>
         <Container style={{ height: '100%' }} className={'d-flex justify-content-center align-items-center'}>
@@ -268,7 +273,7 @@ const ConfigureRecordingSet: FC<{
         <NextButton
           text={t('Start')}
           onClick={(event: React.MouseEvent<HTMLElement, MouseEvent>): void => {
-            setPrevRecordingSetState('external');
+            setRecordingSetState('external');
             onNext(event);
           }}
           disabled={selectedRecordingSetIndex < 0}
@@ -282,8 +287,8 @@ const ConfigureRecordingSet: FC<{
             showingDetails ? 'move-up-in-down-out-start-in' : 'move-up-in-down-out-start-out'
           }`}
           onClick={(): void => {
-            setRecordingSetState(prevState == 'external' ? 'list-preview' : prevState);
-            setPrevRecordingSetState('home');
+            setRecordingSetState(prevState == 'home' || prevState == 'external' ? 'list-preview' : prevState);
+            console.log('clicked');
           }}>
           {t('Show Details')}
         </div>

--- a/src/renderer/components/configure-recording-set-page/dvcfg.tsx
+++ b/src/renderer/components/configure-recording-set-page/dvcfg.tsx
@@ -4,7 +4,7 @@ import { CSSTransition } from 'react-transition-group';
 
 import { Consumer } from '../../types';
 
-import { RecordingPageState } from '.';
+import { RecordingPageState } from './types';
 
 export const Dvcfg: FC<{
   setRecordingSetState: Consumer<RecordingPageState>;

--- a/src/renderer/components/configure-recording-set-page/dvcfg.tsx
+++ b/src/renderer/components/configure-recording-set-page/dvcfg.tsx
@@ -1,0 +1,45 @@
+import React, { FC } from 'react';
+import Container from 'react-bootstrap/esm/Container';
+import { CSSTransition } from 'react-transition-group';
+
+import { Consumer } from '../../types';
+
+import { RecordingPageState } from '.';
+
+const Dvcfg: FC<{
+  setRecordingSetState: Consumer<RecordingPageState>;
+  prevState: RecordingPageState;
+  setPrevRecordingSetState: Consumer<RecordingPageState>;
+}> = ({ setRecordingSetState, prevState, setPrevRecordingSetState }) => {
+  const transitionProps = {
+    in: true,
+    appear: true,
+    timeout: 3000,
+    classNames: prevState == 'oto-ini' ? 'slide-right' : 'slide-left',
+  };
+  return (
+    <CSSTransition {...transitionProps}>
+      <Container>
+        <div onClick={() => setRecordingSetState('home')}>^^^^^^^</div>
+        <button
+          onClick={(): void => {
+            setRecordingSetState('oto-ini');
+            setPrevRecordingSetState('dvcfg');
+          }}>
+          {' '}
+          Back{' '}
+        </button>{' '}
+        <div>.dvcfg</div>
+        <button
+          onClick={(): void => {
+            setRecordingSetState('list-preview');
+            setPrevRecordingSetState('dvcfg');
+          }}>
+          Next{' '}
+        </button>{' '}
+      </Container>
+    </CSSTransition>
+  );
+};
+
+export default Dvcfg;

--- a/src/renderer/components/configure-recording-set-page/dvcfg.tsx
+++ b/src/renderer/components/configure-recording-set-page/dvcfg.tsx
@@ -9,8 +9,8 @@ import { RecordingPageState } from '.';
 const Dvcfg: FC<{
   setRecordingSetState: Consumer<RecordingPageState>;
   prevState: RecordingPageState;
-  setPrevRecordingSetState: Consumer<RecordingPageState>;
-}> = ({ setRecordingSetState, prevState, setPrevRecordingSetState }) => {
+}> = ({ setRecordingSetState, prevState }) => {
+  console.log(prevState);
   const transitionProps = {
     in: true,
     appear: true,
@@ -24,7 +24,6 @@ const Dvcfg: FC<{
         <button
           onClick={(): void => {
             setRecordingSetState('oto-ini');
-            setPrevRecordingSetState('dvcfg');
           }}>
           {' '}
           Back{' '}
@@ -33,7 +32,6 @@ const Dvcfg: FC<{
         <button
           onClick={(): void => {
             setRecordingSetState('list-preview');
-            setPrevRecordingSetState('dvcfg');
           }}>
           Next{' '}
         </button>{' '}

--- a/src/renderer/components/configure-recording-set-page/dvcfg.tsx
+++ b/src/renderer/components/configure-recording-set-page/dvcfg.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { Button } from 'react-bootstrap';
 import Container from 'react-bootstrap/esm/Container';
 import { CSSTransition } from 'react-transition-group';
 
@@ -20,20 +21,19 @@ export const Dvcfg: FC<{
     <CSSTransition {...transitionProps}>
       <Container>
         <div onClick={() => setRecordingSetState('home')}>^^^^^^^</div>
-        <button
+        <Button
           onClick={(): void => {
             setRecordingSetState('oto-ini');
           }}>
-          {' '}
-          Back{' '}
-        </button>{' '}
+          Back
+        </Button>
         <div>.dvcfg</div>
-        <button
+        <Button
           onClick={(): void => {
             setRecordingSetState('list-preview');
           }}>
-          Next{' '}
-        </button>{' '}
+          Next
+        </Button>
       </Container>
     </CSSTransition>
   );

--- a/src/renderer/components/configure-recording-set-page/dvcfg.tsx
+++ b/src/renderer/components/configure-recording-set-page/dvcfg.tsx
@@ -4,7 +4,7 @@ import { CSSTransition } from 'react-transition-group';
 
 import { Consumer } from '../../types';
 
-import { RecordingPageState } from './types';
+import { RecordingPageState } from '.';
 
 export const Dvcfg: FC<{
   setRecordingSetState: Consumer<RecordingPageState>;

--- a/src/renderer/components/configure-recording-set-page/dvcfg.tsx
+++ b/src/renderer/components/configure-recording-set-page/dvcfg.tsx
@@ -6,11 +6,10 @@ import { Consumer } from '../../types';
 
 import { RecordingPageState } from '.';
 
-const Dvcfg: FC<{
+export const Dvcfg: FC<{
   setRecordingSetState: Consumer<RecordingPageState>;
   prevState: RecordingPageState;
 }> = ({ setRecordingSetState, prevState }) => {
-  console.log(prevState);
   const transitionProps = {
     in: true,
     appear: true,
@@ -39,5 +38,3 @@ const Dvcfg: FC<{
     </CSSTransition>
   );
 };
-
-export default Dvcfg;

--- a/src/renderer/components/configure-recording-set-page/index.tsx
+++ b/src/renderer/components/configure-recording-set-page/index.tsx
@@ -25,8 +25,7 @@ const ConfigureRecordingSetPage: FC<{
   onSetSelected: Consumer<RecordingSet>;
 }> = ({ onNext, onBack, onSetSelected }) => {
   const [recordingSetState, setRecordingSetState] = useState<RecordingPageState>('external');
-  const prevStateWithUndefine = usePrevious(recordingSetState);
-  const prevState: RecordingPageState = prevStateWithUndefine != undefined ? prevStateWithUndefine : 'home';
+  const prevState = usePrevious(recordingSetState) ?? 'home';
 
   switch (recordingSetState) {
     case 'home':

--- a/src/renderer/components/configure-recording-set-page/index.tsx
+++ b/src/renderer/components/configure-recording-set-page/index.tsx
@@ -9,9 +9,10 @@ import './show-details.scss';
 import { Dvcfg } from './dvcfg';
 import { ListPreview } from './list-preview';
 import { OtoIni } from './oto-ini';
-
-export type RecordingPageState = 'home' | 'list-preview' | 'oto-ini' | 'dvcfg' | 'external';
-
+import { RecordingPageState } from './types';
+/*
+Base page to handle configure-recording-set, dvcfg, oto.ini, and list-preview pages
+*/
 const ConfigureRecordingSetPage: FC<{
   onNext: MouseEventHandler<HTMLElement>;
   onBack: MouseEventHandler<HTMLElement>;

--- a/src/renderer/components/configure-recording-set-page/index.tsx
+++ b/src/renderer/components/configure-recording-set-page/index.tsx
@@ -1,268 +1,66 @@
 import log from 'electron-log';
-import React, { FC, Fragment, MouseEventHandler, useContext, useEffect, useState } from 'react';
-import Col from 'react-bootstrap/Col';
-import Container from 'react-bootstrap/Container';
-import Row from 'react-bootstrap/Row';
-import { useTranslation } from 'react-i18next';
-import CSSTransition from 'react-transition-group/CSSTransition';
-import useLocalStorage from 'react-use/lib/useLocalStorage';
+import React, { FC, MouseEventHandler, useState } from 'react';
 
-import { RecordingProjectContext } from '../../contexts';
-import { PROJECT_CONFIG_FILENAME } from '../../env-and-consts';
-import { Consumer, RecordingProject, RecordingSet, ScaleKey, SupportedOctave } from '../../types';
-import {
-  checkFileExistence,
-  deleteFolder,
-  ensureFolderExists,
-  getLSKey,
-  join,
-  naiveSerialize,
-  readFile,
-  writeFile,
-} from '../../utils';
-import BackButton from '../back-button';
-import NextButton from '../next-button';
+import { Consumer, RecordingSet } from '../../types';
 
-import AddRecordingSetButton from './add-recording-set-button';
-import CreatedRecordingSetList from './created-recording-set-list';
-import SetMetaConfiguration from './set-meta-configuration';
-import SetRecordingListConfiguration from './set-recording-list-configuration';
-import { BuiltInRecordingList } from './types';
-
+import ConfigureRecordingSet from './configure-recording-set';
 import './show-details.scss';
+import Dvcfg from './dvcfg';
+import ListPreview from './list-preview';
+import OtoIni from './oto-ini';
 
-interface ProjectFile extends RecordingProject {
-  name: string;
-  recordingSets: RecordingSet[];
-}
-
-const DUMMY_PROJECT_FILE = {
-  name: '',
-  rootPath: '',
-  recordingSets: [],
-};
-
-const BUILT_IN_RECORDING_LISTS: BuiltInRecordingList[] = [
-  'デルタ式英語リストver5 (Delta English Ver. 5)',
-  'Z式CVVC-Normal (Z Chinese CVVC - Normal)',
-];
+export type RecordingPageState = 'home' | 'list-preview' | 'oto-ini' | 'dvcfg' | 'external';
 
 const ConfigureRecordingSetPage: FC<{
   onNext: MouseEventHandler<HTMLElement>;
   onBack: MouseEventHandler<HTMLElement>;
   onSetSelected: Consumer<RecordingSet>;
 }> = ({ onNext, onBack, onSetSelected }) => {
-  const { t } = useTranslation();
-  const { recordingProject } = useContext(RecordingProjectContext);
-  const [projectFile = DUMMY_PROJECT_FILE, setProjectFile] = useLocalStorage<ProjectFile>(
-    getLSKey('ConfigureRecordingSetPage', 'projectFile'),
-    DUMMY_PROJECT_FILE,
-  );
-  const [recordingSets = [], setRecordingSets] = useLocalStorage<RecordingSet[]>(
-    getLSKey('ConfigureRecordingSetPage', 'recordingSets'),
-    [],
-  );
-  const [showingDetails = false, setShowingDetails] = useLocalStorage(
-    getLSKey('ConfigureRecordingSetPage', 'showingDetails'),
-    false,
-  );
-  const [canWrite, setCanWrite] = useState(false);
+  const [recordingSetState, setRecordingSetState] = useState<RecordingPageState>('home');
+  const [prevRecordingSetState, setPrevRecordingSetState] = useState<RecordingPageState>('external');
 
-  useEffect(() => {
-    if (recordingProject) {
-      (async (): Promise<void> => {
-        const { rootPath } = recordingProject;
-        const configFilePath = join(rootPath, PROJECT_CONFIG_FILENAME);
-
-        const fileExistence = await checkFileExistence(configFilePath);
-        if (!fileExistence) {
-          setProjectFile(DUMMY_PROJECT_FILE);
-        } else if (fileExistence === 'folder') {
-          throw new Error(`Config file cannot be read because it is a directory: ${configFilePath}`);
-        } else {
-          // TODO Write a loader
-          const projectState = JSON.parse(await readFile(configFilePath)) as ProjectFile;
-          setProjectFile(projectState);
-          setRecordingSets(projectState.recordingSets);
-        }
-        setCanWrite(true);
-      })();
+  switch (recordingSetState) {
+    case 'home':
+      return (
+        <ConfigureRecordingSet
+          onNext={onNext}
+          onBack={onBack}
+          onSetSelected={onSetSelected}
+          setRecordingSetState={setRecordingSetState}
+          setPrevRecordingSetState={setPrevRecordingSetState}
+          prevState={prevRecordingSetState}
+        />
+      );
+    case 'list-preview':
+      return (
+        <ListPreview
+          setRecordingSetState={setRecordingSetState}
+          prevState={prevRecordingSetState}
+          setPrevRecordingSetState={setPrevRecordingSetState}
+        />
+      );
+    case 'oto-ini':
+      return (
+        <OtoIni
+          setRecordingSetState={setRecordingSetState}
+          prevState={prevRecordingSetState}
+          setPrevRecordingSetState={setPrevRecordingSetState}
+        />
+      );
+    case 'dvcfg':
+      return (
+        <Dvcfg
+          setRecordingSetState={setRecordingSetState}
+          prevState={prevRecordingSetState}
+          setPrevRecordingSetState={setPrevRecordingSetState}
+        />
+      );
+    default: {
+      const error = new Error(`Unknown pageState: ${recordingSetState}`);
+      log.error(error);
+      throw error;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [naiveSerialize(recordingProject), setProjectFile, setRecordingSets]);
-
-  useEffect(() => {
-    if (projectFile.recordingSets.length) {
-      // FIXME Need real loading
-      setRecordingSets(projectFile.recordingSets);
-    }
-  }, [projectFile, setRecordingSets]);
-
-  const [chosenKey = 'C', setChosenKey] = useLocalStorage<ScaleKey>(
-    getLSKey('ConfigureRecordingSetPage', 'chosenKey'),
-    'C',
-  );
-  const [chosenOctave = 3, setChosenOctave] = useLocalStorage<SupportedOctave>(
-    getLSKey('ConfigureRecordingSetPage', 'chosenOctave'),
-    3,
-  );
-  const [chosenName = '', setChosenName] = useLocalStorage(getLSKey('ConfigureRecordingSetPage', 'chosenName'), '');
-  const [chosenBuiltInList = '', rawSetChosenBuiltInList] = useLocalStorage(
-    getLSKey('ConfigureRecordingSetPage', 'chosenBuiltInList'),
-    '',
-  );
-  const [chosenCustomListPath = '', rawSetChosenCustomListPath] = useLocalStorage(
-    getLSKey('ConfigureRecordingSetPage', 'chosenCustomListPath'),
-    '',
-  );
-  const setChosenBuiltInList = (name: string): void => {
-    rawSetChosenBuiltInList(name);
-    if (name) {
-      rawSetChosenCustomListPath('');
-    }
-  };
-  const setChosenCustomListPath = (filePath: string): void => {
-    rawSetChosenCustomListPath(filePath);
-    if (filePath) {
-      rawSetChosenBuiltInList('');
-    }
-  };
-
-  const addRecordingSet = async (newRecordingSet: RecordingSet): Promise<void> => {
-    if (recordingProject) {
-      const recordingSetPath = join(recordingProject.rootPath, newRecordingSet.name);
-      await ensureFolderExists(recordingSetPath);
-      setRecordingSets([...recordingSets, newRecordingSet]);
-    }
-  };
-
-  const [selectedRecordingSetIndex = -1, setSelectedRecordingSetIndex] = useLocalStorage<number>(
-    getLSKey('ConfigureRecordingSetPage', 'selectedRecordingSetIndex'),
-    -1,
-  );
-
-  const removeRecordingSet = async (setToDelete: RecordingSet): Promise<void> => {
-    const willDelete = confirm(`Are you sure you want to delete ${setToDelete.name}?`);
-    if (willDelete) {
-      const newSets = recordingSets.filter((x) => x !== setToDelete);
-      setRecordingSets(newSets);
-
-      if (recordingSets[selectedRecordingSetIndex] === setToDelete) {
-        setSelectedRecordingSetIndex(-1);
-      }
-
-      if (recordingProject) {
-        const willDeleteFiles = confirm(`Are you sure you want to delete the files also?`);
-        if (willDeleteFiles) {
-          const recordingSetPath = join(recordingProject.rootPath, setToDelete.name);
-          return deleteFolder(recordingSetPath);
-        }
-      }
-    }
-  };
-
-  const clearTemporaryItemsOnBack: typeof onBack = (e) => {
-    setCanWrite(false);
-    setChosenKey('C');
-    setChosenOctave(3);
-    setChosenName('');
-    rawSetChosenBuiltInList('');
-    rawSetChosenCustomListPath('');
-    setSelectedRecordingSetIndex(-1);
-    setProjectFile(DUMMY_PROJECT_FILE);
-    setShowingDetails(false);
-    setImmediate(() => onBack(e));
-  };
-
-  useEffect(() => {
-    onSetSelected(recordingSets[selectedRecordingSetIndex]);
-    // We have to ignore onSetSelected because it's new every time
-    // eslint-disable-next-line
-  }, [recordingSets, selectedRecordingSetIndex]);
-
-  useEffect(() => {
-    if (canWrite && recordingProject) {
-      const currentProjectState: Partial<ProjectFile> = {
-        name: recordingProject.name,
-        recordingSets,
-      };
-      writeFile(
-        join(recordingProject.rootPath, PROJECT_CONFIG_FILENAME),
-        JSON.stringify(currentProjectState, null, 2),
-      ).catch(log.error);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [naiveSerialize(recordingProject), naiveSerialize(recordingSets)]);
-
-  return (
-    <Fragment>
-      <BackButton onBack={clearTemporaryItemsOnBack} />
-      <Container style={{ height: '100%' }} className={'d-flex justify-content-center align-items-center'}>
-        <Col>
-          <Row>
-            <SetMetaConfiguration
-              chosenKey={chosenKey}
-              setChosenKey={setChosenKey}
-              chosenOctave={chosenOctave}
-              setChosenOctave={setChosenOctave}
-              chosenName={chosenName}
-              setChosenName={setChosenName}
-            />
-          </Row>
-          <Row>
-            <SetRecordingListConfiguration
-              builtInLists={BUILT_IN_RECORDING_LISTS}
-              chosenBuiltInList={chosenBuiltInList}
-              setChosenBuiltInList={setChosenBuiltInList}
-              chosenCustomListPath={chosenCustomListPath}
-              setChosenCustomListPath={setChosenCustomListPath}
-            />
-            <Col xs={'auto'} sm={'auto'} md={'auto'} lg={'auto'} xl={'auto'}>
-              <AddRecordingSetButton
-                chosenKey={chosenKey}
-                chosenOctave={chosenOctave}
-                chosenName={chosenName}
-                chosenBuiltInList={chosenBuiltInList}
-                chosenCustomListPath={chosenCustomListPath}
-                existingSets={recordingSets}
-                addRecordingSet={addRecordingSet}
-              />
-            </Col>
-          </Row>
-          <Row style={{ marginTop: '1rem' }}>
-            <Col xs={2} sm={2} md={2} lg={2} xl={2}>
-              {t('Created')}
-            </Col>
-            <Col xs={'auto'} sm={8} md={8} lg={8} xl={8}>
-              <CreatedRecordingSetList
-                recordingSets={recordingSets}
-                removeRecordingSet={removeRecordingSet}
-                selectedRecordingSetIndex={selectedRecordingSetIndex}
-                setSelectedRecordingSetIndex={setSelectedRecordingSetIndex}
-                style={{
-                  maxHeight: '14rem',
-                  overflowY: 'scroll',
-                }}
-              />
-            </Col>
-            <Col />
-          </Row>
-        </Col>
-      </Container>
-      <NextButton text={t('Start')} onClick={onNext} disabled={selectedRecordingSetIndex < 0} />
-      <CSSTransition in={showingDetails} timeout={200} classNames={'move-up-in-down-out'}>
-        <div
-          // position={'bottom-center'}
-          style={{ bottom: undefined, display: 'hidden' }}
-          className={`show-details ${
-            showingDetails ? 'move-up-in-down-out-start-in' : 'move-up-in-down-out-start-out'
-          }`}
-          onClick={(): void => setShowingDetails(showingDetails)}>
-          {t('Show Details')}
-        </div>
-      </CSSTransition>
-    </Fragment>
-  );
+  }
 };
 
 export default ConfigureRecordingSetPage;

--- a/src/renderer/components/configure-recording-set-page/index.tsx
+++ b/src/renderer/components/configure-recording-set-page/index.tsx
@@ -1,5 +1,6 @@
 import log from 'electron-log';
 import React, { FC, MouseEventHandler, useState } from 'react';
+import { usePrevious } from 'react-use';
 
 import { Consumer, RecordingSet } from '../../types';
 
@@ -16,8 +17,9 @@ const ConfigureRecordingSetPage: FC<{
   onBack: MouseEventHandler<HTMLElement>;
   onSetSelected: Consumer<RecordingSet>;
 }> = ({ onNext, onBack, onSetSelected }) => {
-  const [recordingSetState, setRecordingSetState] = useState<RecordingPageState>('home');
-  const [prevRecordingSetState, setPrevRecordingSetState] = useState<RecordingPageState>('external');
+  const [recordingSetState, setRecordingSetState] = useState<RecordingPageState>('external');
+  const prevStateWithUndefine = usePrevious(recordingSetState);
+  const prevState: RecordingPageState = prevStateWithUndefine != undefined ? prevStateWithUndefine : 'home';
 
   switch (recordingSetState) {
     case 'home':
@@ -27,34 +29,27 @@ const ConfigureRecordingSetPage: FC<{
           onBack={onBack}
           onSetSelected={onSetSelected}
           setRecordingSetState={setRecordingSetState}
-          setPrevRecordingSetState={setPrevRecordingSetState}
-          prevState={prevRecordingSetState}
+          prevState={prevState}
+          currState={recordingSetState}
+        />
+      );
+    case 'external':
+      return (
+        <ConfigureRecordingSet
+          onNext={onNext}
+          onBack={onBack}
+          onSetSelected={onSetSelected}
+          setRecordingSetState={setRecordingSetState}
+          prevState={prevState}
+          currState={recordingSetState}
         />
       );
     case 'list-preview':
-      return (
-        <ListPreview
-          setRecordingSetState={setRecordingSetState}
-          prevState={prevRecordingSetState}
-          setPrevRecordingSetState={setPrevRecordingSetState}
-        />
-      );
+      return <ListPreview setRecordingSetState={setRecordingSetState} prevState={prevState} />;
     case 'oto-ini':
-      return (
-        <OtoIni
-          setRecordingSetState={setRecordingSetState}
-          prevState={prevRecordingSetState}
-          setPrevRecordingSetState={setPrevRecordingSetState}
-        />
-      );
+      return <OtoIni setRecordingSetState={setRecordingSetState} prevState={prevState} />;
     case 'dvcfg':
-      return (
-        <Dvcfg
-          setRecordingSetState={setRecordingSetState}
-          prevState={prevRecordingSetState}
-          setPrevRecordingSetState={setPrevRecordingSetState}
-        />
-      );
+      return <Dvcfg setRecordingSetState={setRecordingSetState} prevState={prevState} />;
     default: {
       const error = new Error(`Unknown pageState: ${recordingSetState}`);
       log.error(error);

--- a/src/renderer/components/configure-recording-set-page/index.tsx
+++ b/src/renderer/components/configure-recording-set-page/index.tsx
@@ -4,11 +4,11 @@ import { usePrevious } from 'react-use';
 
 import { Consumer, RecordingSet } from '../../types';
 
-import ConfigureRecordingSet from './configure-recording-set';
+import { ConfigureRecordingSet } from './configure-recording-set';
 import './show-details.scss';
-import Dvcfg from './dvcfg';
-import ListPreview from './list-preview';
-import OtoIni from './oto-ini';
+import { Dvcfg } from './dvcfg';
+import { ListPreview } from './list-preview';
+import { OtoIni } from './oto-ini';
 
 export type RecordingPageState = 'home' | 'list-preview' | 'oto-ini' | 'dvcfg' | 'external';
 

--- a/src/renderer/components/configure-recording-set-page/index.tsx
+++ b/src/renderer/components/configure-recording-set-page/index.tsx
@@ -9,7 +9,13 @@ import './show-details.scss';
 import { Dvcfg } from './dvcfg';
 import { ListPreview } from './list-preview';
 import { OtoIni } from './oto-ini';
-import { RecordingPageState } from './types';
+/*
+ Represents the page states controlled by configure-recording-set.
+ 'external' represents pages external from this system
+  - it's used to determine which transition should be used for the entering home page
+*/
+export type RecordingPageState = 'home' | 'list-preview' | 'oto-ini' | 'dvcfg' | 'external';
+
 /*
 Base page to handle configure-recording-set, dvcfg, oto.ini, and list-preview pages
 */

--- a/src/renderer/components/configure-recording-set-page/list-preview.tsx
+++ b/src/renderer/components/configure-recording-set-page/list-preview.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import Container from 'react-bootstrap/esm/Container';
 import { CSSTransition } from 'react-transition-group';
+import { usePrevious } from 'react-use';
 
 import { Consumer } from '../../types';
 
@@ -9,8 +10,8 @@ import { RecordingPageState } from '.';
 const ListPreview: FC<{
   setRecordingSetState: Consumer<RecordingPageState>;
   prevState: RecordingPageState;
-  setPrevRecordingSetState: Consumer<RecordingPageState>;
-}> = ({ setRecordingSetState, prevState, setPrevRecordingSetState }) => {
+}> = ({ setRecordingSetState, prevState }) => {
+  console.log(prevState);
   const transitionProps = {
     in: true,
     appear: true,
@@ -23,14 +24,12 @@ const ListPreview: FC<{
         <div
           onClick={(): void => {
             setRecordingSetState('home');
-            setPrevRecordingSetState('list-preview');
           }}>
           ^^^^^^^
         </div>
         <button
           onClick={(): void => {
             setRecordingSetState('dvcfg');
-            setPrevRecordingSetState('list-preview');
           }}>
           {' '}
           Back{' '}
@@ -39,7 +38,6 @@ const ListPreview: FC<{
         <button
           onClick={(): void => {
             setRecordingSetState('oto-ini');
-            setPrevRecordingSetState('list-preview');
           }}>
           Next{' '}
         </button>

--- a/src/renderer/components/configure-recording-set-page/list-preview.tsx
+++ b/src/renderer/components/configure-recording-set-page/list-preview.tsx
@@ -4,7 +4,7 @@ import { CSSTransition } from 'react-transition-group';
 
 import { Consumer } from '../../types';
 
-import { RecordingPageState } from '.';
+import { RecordingPageState } from './types';
 
 export const ListPreview: FC<{
   setRecordingSetState: Consumer<RecordingPageState>;

--- a/src/renderer/components/configure-recording-set-page/list-preview.tsx
+++ b/src/renderer/components/configure-recording-set-page/list-preview.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { Button } from 'react-bootstrap';
 import Container from 'react-bootstrap/esm/Container';
 import { CSSTransition } from 'react-transition-group';
 
@@ -25,20 +26,19 @@ export const ListPreview: FC<{
           }}>
           ^^^^^^^
         </div>
-        <button
+        <Button
           onClick={(): void => {
             setRecordingSetState('dvcfg');
           }}>
-          {' '}
-          Back{' '}
-        </button>
+          Back
+        </Button>
         <div>List Preview</div>
-        <button
+        <Button
           onClick={(): void => {
             setRecordingSetState('oto-ini');
           }}>
-          Next{' '}
-        </button>
+          Next
+        </Button>
       </Container>
     </CSSTransition>
   );

--- a/src/renderer/components/configure-recording-set-page/list-preview.tsx
+++ b/src/renderer/components/configure-recording-set-page/list-preview.tsx
@@ -4,7 +4,7 @@ import { CSSTransition } from 'react-transition-group';
 
 import { Consumer } from '../../types';
 
-import { RecordingPageState } from './types';
+import { RecordingPageState } from '.';
 
 export const ListPreview: FC<{
   setRecordingSetState: Consumer<RecordingPageState>;

--- a/src/renderer/components/configure-recording-set-page/list-preview.tsx
+++ b/src/renderer/components/configure-recording-set-page/list-preview.tsx
@@ -1,0 +1,51 @@
+import React, { FC } from 'react';
+import Container from 'react-bootstrap/esm/Container';
+import { CSSTransition } from 'react-transition-group';
+
+import { Consumer } from '../../types';
+
+import { RecordingPageState } from '.';
+
+const ListPreview: FC<{
+  setRecordingSetState: Consumer<RecordingPageState>;
+  prevState: RecordingPageState;
+  setPrevRecordingSetState: Consumer<RecordingPageState>;
+}> = ({ setRecordingSetState, prevState, setPrevRecordingSetState }) => {
+  const transitionProps = {
+    in: true,
+    appear: true,
+    timeout: 3000,
+    classNames: prevState == 'oto-ini' ? 'slide-left' : prevState == 'dvcfg' ? 'slide-right' : 'slide-down',
+  };
+  return (
+    <CSSTransition {...transitionProps}>
+      <Container>
+        <div
+          onClick={(): void => {
+            setRecordingSetState('home');
+            setPrevRecordingSetState('list-preview');
+          }}>
+          ^^^^^^^
+        </div>
+        <button
+          onClick={(): void => {
+            setRecordingSetState('dvcfg');
+            setPrevRecordingSetState('list-preview');
+          }}>
+          {' '}
+          Back{' '}
+        </button>
+        <div>List Preview</div>
+        <button
+          onClick={(): void => {
+            setRecordingSetState('oto-ini');
+            setPrevRecordingSetState('list-preview');
+          }}>
+          Next{' '}
+        </button>
+      </Container>
+    </CSSTransition>
+  );
+};
+
+export default ListPreview;

--- a/src/renderer/components/configure-recording-set-page/list-preview.tsx
+++ b/src/renderer/components/configure-recording-set-page/list-preview.tsx
@@ -1,17 +1,15 @@
 import React, { FC } from 'react';
 import Container from 'react-bootstrap/esm/Container';
 import { CSSTransition } from 'react-transition-group';
-import { usePrevious } from 'react-use';
 
 import { Consumer } from '../../types';
 
 import { RecordingPageState } from '.';
 
-const ListPreview: FC<{
+export const ListPreview: FC<{
   setRecordingSetState: Consumer<RecordingPageState>;
   prevState: RecordingPageState;
 }> = ({ setRecordingSetState, prevState }) => {
-  console.log(prevState);
   const transitionProps = {
     in: true,
     appear: true,
@@ -45,5 +43,3 @@ const ListPreview: FC<{
     </CSSTransition>
   );
 };
-
-export default ListPreview;

--- a/src/renderer/components/configure-recording-set-page/oto-ini.tsx
+++ b/src/renderer/components/configure-recording-set-page/oto-ini.tsx
@@ -4,7 +4,7 @@ import { CSSTransition } from 'react-transition-group';
 
 import { Consumer } from '../../types';
 
-import { RecordingPageState } from '.';
+import { RecordingPageState } from './types';
 
 export const OtoIni: FC<{
   setRecordingSetState: Consumer<RecordingPageState>;

--- a/src/renderer/components/configure-recording-set-page/oto-ini.tsx
+++ b/src/renderer/components/configure-recording-set-page/oto-ini.tsx
@@ -1,17 +1,15 @@
 import React, { FC } from 'react';
 import { Container } from 'react-bootstrap';
 import { CSSTransition } from 'react-transition-group';
-import { usePrevious } from 'react-use';
 
 import { Consumer } from '../../types';
 
 import { RecordingPageState } from '.';
 
-const OtoIni: FC<{
+export const OtoIni: FC<{
   setRecordingSetState: Consumer<RecordingPageState>;
   prevState: RecordingPageState;
 }> = ({ setRecordingSetState, prevState }) => {
-  console.log(prevState);
   const transitionProps = {
     in: true,
     appear: true,
@@ -40,5 +38,3 @@ const OtoIni: FC<{
     </CSSTransition>
   );
 };
-
-export default OtoIni;

--- a/src/renderer/components/configure-recording-set-page/oto-ini.tsx
+++ b/src/renderer/components/configure-recording-set-page/oto-ini.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { Container } from 'react-bootstrap';
 import { CSSTransition } from 'react-transition-group';
+import { usePrevious } from 'react-use';
 
 import { Consumer } from '../../types';
 
@@ -9,8 +10,8 @@ import { RecordingPageState } from '.';
 const OtoIni: FC<{
   setRecordingSetState: Consumer<RecordingPageState>;
   prevState: RecordingPageState;
-  setPrevRecordingSetState: Consumer<RecordingPageState>;
-}> = ({ setRecordingSetState, prevState, setPrevRecordingSetState }) => {
+}> = ({ setRecordingSetState, prevState }) => {
+  console.log(prevState);
   const transitionProps = {
     in: true,
     appear: true,
@@ -24,7 +25,6 @@ const OtoIni: FC<{
         <button
           onClick={(): void => {
             setRecordingSetState('list-preview');
-            setPrevRecordingSetState('oto-ini');
           }}>
           {' '}
           Back{' '}
@@ -33,7 +33,6 @@ const OtoIni: FC<{
         <button
           onClick={(): void => {
             setRecordingSetState('dvcfg');
-            setPrevRecordingSetState('oto-ini');
           }}>
           Next{' '}
         </button>{' '}

--- a/src/renderer/components/configure-recording-set-page/oto-ini.tsx
+++ b/src/renderer/components/configure-recording-set-page/oto-ini.tsx
@@ -1,0 +1,45 @@
+import React, { FC } from 'react';
+import { Container } from 'react-bootstrap';
+import { CSSTransition } from 'react-transition-group';
+
+import { Consumer } from '../../types';
+
+import { RecordingPageState } from '.';
+
+const OtoIni: FC<{
+  setRecordingSetState: Consumer<RecordingPageState>;
+  prevState: RecordingPageState;
+  setPrevRecordingSetState: Consumer<RecordingPageState>;
+}> = ({ setRecordingSetState, prevState, setPrevRecordingSetState }) => {
+  const transitionProps = {
+    in: true,
+    appear: true,
+    timeout: 3000,
+    classNames: prevState == 'list-preview' ? 'slide-right' : 'slide-left',
+  };
+  return (
+    <CSSTransition {...transitionProps}>
+      <Container>
+        <div onClick={() => setRecordingSetState('home')}>^^^^^^^</div>
+        <button
+          onClick={(): void => {
+            setRecordingSetState('list-preview');
+            setPrevRecordingSetState('oto-ini');
+          }}>
+          {' '}
+          Back{' '}
+        </button>{' '}
+        <div>Oto.ini</div>
+        <button
+          onClick={(): void => {
+            setRecordingSetState('dvcfg');
+            setPrevRecordingSetState('oto-ini');
+          }}>
+          Next{' '}
+        </button>{' '}
+      </Container>
+    </CSSTransition>
+  );
+};
+
+export default OtoIni;

--- a/src/renderer/components/configure-recording-set-page/oto-ini.tsx
+++ b/src/renderer/components/configure-recording-set-page/oto-ini.tsx
@@ -4,7 +4,7 @@ import { CSSTransition } from 'react-transition-group';
 
 import { Consumer } from '../../types';
 
-import { RecordingPageState } from './types';
+import { RecordingPageState } from '.';
 
 export const OtoIni: FC<{
   setRecordingSetState: Consumer<RecordingPageState>;

--- a/src/renderer/components/configure-recording-set-page/oto-ini.tsx
+++ b/src/renderer/components/configure-recording-set-page/oto-ini.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { Container } from 'react-bootstrap';
+import { Button, Container } from 'react-bootstrap';
 import { CSSTransition } from 'react-transition-group';
 
 import { Consumer } from '../../types';
@@ -20,20 +20,19 @@ export const OtoIni: FC<{
     <CSSTransition {...transitionProps}>
       <Container>
         <div onClick={() => setRecordingSetState('home')}>^^^^^^^</div>
-        <button
+        <Button
           onClick={(): void => {
             setRecordingSetState('list-preview');
           }}>
-          {' '}
-          Back{' '}
-        </button>{' '}
+          Back
+        </Button>
         <div>Oto.ini</div>
-        <button
+        <Button
           onClick={(): void => {
             setRecordingSetState('dvcfg');
           }}>
-          Next{' '}
-        </button>{' '}
+          Next
+        </Button>
       </Container>
     </CSSTransition>
   );

--- a/src/renderer/components/configure-recording-set-page/types.ts
+++ b/src/renderer/components/configure-recording-set-page/types.ts
@@ -1,9 +1,3 @@
 export type BuiltInRecordingList =
   | 'デルタ式英語リストver5 (Delta English Ver. 5)'
   | 'Z式CVVC-Normal (Z Chinese CVVC - Normal)';
-/*
- Represents the page states controlled by configure-recording-set.
- 'external' represents pages external from this system
-  - it's used to determine which transition should be used for the entering home page
-*/
-export type RecordingPageState = 'home' | 'list-preview' | 'oto-ini' | 'dvcfg' | 'external';

--- a/src/renderer/components/configure-recording-set-page/types.ts
+++ b/src/renderer/components/configure-recording-set-page/types.ts
@@ -1,3 +1,9 @@
 export type BuiltInRecordingList =
   | 'デルタ式英語リストver5 (Delta English Ver. 5)'
   | 'Z式CVVC-Normal (Z Chinese CVVC - Normal)';
+/*
+ Represents the page states controlled by configure-recording-set.
+ 'external' represents pages external from this system
+  - it's used to determine which transition should be used for the entering home page
+*/
+export type RecordingPageState = 'home' | 'list-preview' | 'oto-ini' | 'dvcfg' | 'external';

--- a/src/renderer/index.scss
+++ b/src/renderer/index.scss
@@ -27,64 +27,11 @@ div#app {
   height: 100vh;
 }
 
-.image-button-dark {
-  background: #3A3A3A;
-  border: #3A3A3A;
-  border-radius: 35px;
-}
-
-.image-button-dark:hover {
-  filter: invert(60%);
-}
-
-.image-button-dark:focus:not(.hover) {
-  border: none;
-  box-shadow: 0 0 0 4px #6c757d;
-  outline: none;
-}
-
-.image-button-dark:focus { // focus and hover
-  border: none;
-  box-shadow: 0 0 0 4px #808080;
-  outline: none;
-}
-
-.image-button {
-  background: white;
-  border: white;
-  border-radius: 35px;
-}
-
-.image-button:hover {
-  filter: invert(60%);
-}
-
-.image-button:focus:not(.hover) {
-  border: none;
-  box-shadow: 0 0 0 4px #6c757d;
-  outline: none;
-}
-
-.image-button:focus { // focus and hover
-  border: none;
-  box-shadow: 0 0 0 4px #808080;
-  outline: none;
-}
-
 ::-webkit-scrollbar {
   width: 0;
   background: transparent;
 }
 
-// .alert-enter {
-//   opacity: 0;
-//   transform: scale(0.9);
-// }
-// .alert-enter-active {
-//   opacity: 1;
-//   transform: translateX(0);
-//   transition: opacity 3000ms, transform 3000ms;
-// }
 .slide-down-appear {
   opacity: 0;
   transform: translateY(-100%);

--- a/src/renderer/index.scss
+++ b/src/renderer/index.scss
@@ -27,64 +27,6 @@ div#app {
   height: 100vh;
 }
 
-.image-button-dark {
-  background: #3A3A3A;
-  border: #3A3A3A;
-  border-radius: 35px;
-}
-
-.image-button-dark:hover {
-  filter: invert(60%);
-}
-
-.image-button-dark:focus:not(.hover) {
-  border: none;
-  box-shadow: 0 0 0 4px #6c757d;
-  outline: none;
-}
-
-.image-button-dark:focus { // focus and hover
-  border: none;
-  box-shadow: 0 0 0 4px #808080;
-  outline: none;
-}
-
-.image-button {
-  background: white;
-  border: white;
-  border-radius: 35px;
-}
-
-.image-button:hover {
-  filter: invert(60%);
-}
-
-.image-button:focus:not(.hover) {
-  border: none;
-  box-shadow: 0 0 0 4px #6c757d;
-  outline: none;
-}
-
-.image-button:focus { // focus and hover
-  border: none;
-  box-shadow: 0 0 0 4px #808080;
-  outline: none;
-}
-
-::-webkit-scrollbar {
-  width: 0;
-  background: transparent;
-}
-
-// .alert-enter {
-//   opacity: 0;
-//   transform: scale(0.9);
-// }
-// .alert-enter-active {
-//   opacity: 1;
-//   transform: translateX(0);
-//   transition: opacity 3000ms, transform 3000ms;
-// }
 .slide-down-appear {
   opacity: 0;
   transform: translateY(-100%);

--- a/src/renderer/index.scss
+++ b/src/renderer/index.scss
@@ -27,11 +27,6 @@ div#app {
   height: 100vh;
 }
 
-::-webkit-scrollbar {
-  width: 0;
-  background: transparent;
-}
-
 .slide-down-appear {
   opacity: 0;
   transform: translateY(-100%);

--- a/src/renderer/index.scss
+++ b/src/renderer/index.scss
@@ -27,11 +27,64 @@ div#app {
   height: 100vh;
 }
 
+.image-button-dark {
+  background: #3A3A3A;
+  border: #3A3A3A;
+  border-radius: 35px;
+}
+
+.image-button-dark:hover {
+  filter: invert(60%);
+}
+
+.image-button-dark:focus:not(.hover) {
+  border: none;
+  box-shadow: 0 0 0 4px #6c757d;
+  outline: none;
+}
+
+.image-button-dark:focus { // focus and hover
+  border: none;
+  box-shadow: 0 0 0 4px #808080;
+  outline: none;
+}
+
+.image-button {
+  background: white;
+  border: white;
+  border-radius: 35px;
+}
+
+.image-button:hover {
+  filter: invert(60%);
+}
+
+.image-button:focus:not(.hover) {
+  border: none;
+  box-shadow: 0 0 0 4px #6c757d;
+  outline: none;
+}
+
+.image-button:focus { // focus and hover
+  border: none;
+  box-shadow: 0 0 0 4px #808080;
+  outline: none;
+}
+
 ::-webkit-scrollbar {
   width: 0;
   background: transparent;
 }
 
+// .alert-enter {
+//   opacity: 0;
+//   transform: scale(0.9);
+// }
+// .alert-enter-active {
+//   opacity: 1;
+//   transform: translateX(0);
+//   transition: opacity 3000ms, transform 3000ms;
+// }
 .slide-down-appear {
   opacity: 0;
   transform: translateY(-100%);

--- a/src/renderer/index.scss
+++ b/src/renderer/index.scss
@@ -21,3 +21,127 @@ td:empty::after,
 .place-held:empty::after {
   content: '\00a0';
 }
+// Global styles
+div#app {
+  width: 100vw;
+  height: 100vh;
+}
+
+.image-button-dark {
+  background: #3A3A3A;
+  border: #3A3A3A;
+  border-radius: 35px;
+}
+
+.image-button-dark:hover {
+  filter: invert(60%);
+}
+
+.image-button-dark:focus:not(.hover) {
+  border: none;
+  box-shadow: 0 0 0 4px #6c757d;
+  outline: none;
+}
+
+.image-button-dark:focus { // focus and hover
+  border: none;
+  box-shadow: 0 0 0 4px #808080;
+  outline: none;
+}
+
+.image-button {
+  background: white;
+  border: white;
+  border-radius: 35px;
+}
+
+.image-button:hover {
+  filter: invert(60%);
+}
+
+.image-button:focus:not(.hover) {
+  border: none;
+  box-shadow: 0 0 0 4px #6c757d;
+  outline: none;
+}
+
+.image-button:focus { // focus and hover
+  border: none;
+  box-shadow: 0 0 0 4px #808080;
+  outline: none;
+}
+
+::-webkit-scrollbar {
+  width: 0;
+  background: transparent;
+}
+
+// .alert-enter {
+//   opacity: 0;
+//   transform: scale(0.9);
+// }
+// .alert-enter-active {
+//   opacity: 1;
+//   transform: translateX(0);
+//   transition: opacity 3000ms, transform 3000ms;
+// }
+.slide-down-appear {
+  opacity: 0;
+  transform: translateY(-100%);
+}
+.slide-down-appear-active {
+  opacity: 1;
+  transform: translateY(0%);
+  transition: opacity 300ms, transform 300ms;
+}
+
+.slide-left-appear {
+  opacity: 0;
+  transform: translateX(100%);
+}
+.slide-left-appear-active {
+  opacity: 1;
+  transform: translateX(0%);
+  transition: opacity 300ms, transform 300ms;
+}
+
+.slide-right-appear {
+  opacity: 0;
+  transform: translateX(-100%);
+}
+.slide-right-appear-active {
+  opacity: 1;
+  transform: translateX(0%);
+  transition: opacity 300ms, transform 300ms;
+}
+.config-rec-set-appear {
+  opacity: 0;
+  transform: translateY(100%);
+}
+.config-rec-set-appear-active {
+  opacity: 1;
+  transform: translateY(0%);
+  transition: opacity 300ms, transform 300ms;
+}
+.config-rec-set-exit {
+  opacity: 1;
+  transform: translateY(0%);
+}
+.config-rec-set-exit-active {
+  opacity: 0;
+  transform: translateY(-100%);
+  transition: opacity 300ms, transform 300ms;
+}
+
+// Unless specified otherwise, all images are not draggable and not selectable
+* {
+  -webkit-user-drag: none;
+  user-select: none;
+}
+
+// https://stackoverflow.com/a/42225797
+td:empty::after,
+.list-group-item:empty::after,
+.place-held:empty::after {
+  content: '\00a0';
+}

--- a/src/renderer/types/global.d.ts
+++ b/src/renderer/types/global.d.ts
@@ -1,1 +1,3 @@
 declare const __static: string;
+//Bug fix for ts error in react-use
+type PositionError = GeolocationPositionError;

--- a/src/renderer/types/global.d.ts
+++ b/src/renderer/types/global.d.ts
@@ -1,3 +1,3 @@
 declare const __static: string;
-//Bug fix for ts error in react-use
+// Bug fix for ts error in react-use
 type PositionError = GeolocationPositionError;


### PR DESCRIPTION
Animated transitions between the list-preview, .dvcfg, oto.ini, and configure-recording set pages.  list-preview, .dvcfg, and oto.ini pages are still dummy versions of themselves.
Apologies for the lack of commits - code was originally on the garretje/animations branch, but there ended up being too accidentally committed files for a PR, so I moved all of the intended changes to a new branch