### PR TITLE
feat: make app window hide rather than close to preserve app state

### DIFF
--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -1,0 +1,3 @@
+export class AssertionError extends Error {
+  name = 'AssertionError';
+}


### PR DESCRIPTION
When the user presses `x` on the application window, the app should just hide the window without releasing the resources. The boilerplate code closes the window, causing a new window to be created on `activate`, which has to load the entire page from scratch. Hiding this window will allow the page to stay open in the background, which is closer to how native macOS apps behave.