### PR TITLE
fix: correct the notification title on Windows

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -200,7 +200,10 @@ if (!isFirstInstance) {
 
   electronRemoteInitialize();
   // For Windows notifications. See https://www.electronjs.org/docs/tutorial/notifications#windows.
-  app.setAppUserModelId(process.execPath);
+  // But need to use appId here. See https://www.electron.build/configuration/nsis.html#guid-vs-application-name.
+  // Requiring the builder config file ensures the `appId` stays in sync.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  app.setAppUserModelId(require('../../electron-builder').appId);
 
   if (module.hot) {
     module.hot.accept();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -199,6 +199,8 @@ if (!isFirstInstance) {
   });
 
   electronRemoteInitialize();
+  // For Windows notifications. See https://www.electronjs.org/docs/tutorial/notifications#windows.
+  app.setAppUserModelId(process.execPath);
 
   if (module.hot) {
     module.hot.accept();


### PR DESCRIPTION
Fixes #40.
![windows-10-notification-has-correct-title-and-icon](https://user-images.githubusercontent.com/50057288/111065962-c242d080-8479-11eb-820a-45b7ff576e06.gif)
