### PR TITLE
Revert "fix(deps): bump dexie from 3.0.3 to 3.2.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "chardet": "^1.4.0",
         "chokidar": "^3.5.2",
         "delta_eng_ver5": "file:external/delta_eng_ver5",
-        "dexie": "^3.2.0",
+        "dexie": "^3.0.1",
         "dv_jpn_list_by_alex": "file:external/dv_jpn_list_by_alex",
         "electron-log": "^4.4.3",
         "electron-updater": "^4.6.1",
@@ -7537,9 +7537,9 @@
       "dev": true
     },
     "node_modules/dexie": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.0.tgz",
-      "integrity": "sha512-OpS8ss1CLHYAhxRu6hT+/Gt1uLhKCf0O18xHBdRGlemOWXXRiiOZ0ty1/bACIJzGt1DGmvarzrPwYYt9EkRZfw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.0.3.tgz",
+      "integrity": "sha512-BSFhGpngnCl1DOr+8YNwBDobRMH0ziJs2vts69VilwetHYOtEDcLqo7d/XiIphM0tJZ2rPPyAGd31lgH2Ln3nw==",
       "engines": {
         "node": ">=6.0"
       }
@@ -36100,9 +36100,9 @@
       "dev": true
     },
     "dexie": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.0.tgz",
-      "integrity": "sha512-OpS8ss1CLHYAhxRu6hT+/Gt1uLhKCf0O18xHBdRGlemOWXXRiiOZ0ty1/bACIJzGt1DGmvarzrPwYYt9EkRZfw=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.0.3.tgz",
+      "integrity": "sha512-BSFhGpngnCl1DOr+8YNwBDobRMH0ziJs2vts69VilwetHYOtEDcLqo7d/XiIphM0tJZ2rPPyAGd31lgH2Ln3nw=="
     },
     "diff-sequences": {
       "version": "27.4.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "chardet": "^1.4.0",
     "chokidar": "^3.5.2",
     "delta_eng_ver5": "file:external/delta_eng_ver5",
-    "dexie": "^3.2.0",
+    "dexie": "^3.0.1",
     "dv_jpn_list_by_alex": "file:external/dv_jpn_list_by_alex",
     "electron-log": "^4.4.3",
     "electron-updater": "^4.6.1",


### PR DESCRIPTION
Reverts team-aie/app#523.

The 3.2.0 version is giving the following error:
```
Uncaught Error: require() of ES Module node_modules/dexie/dist/modern/dexie.mjs not supported.
Instead change the require of node_modules/dexie/dist/modern/dexie.mjs to a dynamic import() which is available in all CommonJS modules.
```