### PR TITLE
feat: add untested support for Apple Silicon and Universal apps

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -124,21 +124,51 @@ jobs:
       - run: npm run test
       - name: Package Production App
         run: npm run dist:macos -- -p never
-      - name: Upload Packaged App
+      - name: Upload Packaged App (x64)
         uses: actions/upload-artifact@v2.3.1
         with:
           name: aie-${{ steps.find-new-version.outputs.new_release_version }}.dmg.zip
           path: dist/aie-${{ steps.find-new-version.outputs.new_release_version }}.dmg
-      - name: Upload Packaged Zip
+      - name: Upload Packaged Zip (x64)
         uses: actions/upload-artifact@v2.3.1
         with:
           name: aie-${{ steps.find-new-version.outputs.new_release_version }}-mac.zip.zip
           path: dist/aie-${{ steps.find-new-version.outputs.new_release_version }}-mac.zip
-      - name: Upload Blockmap
+      - name: Upload Blockmap (x64)
         uses: actions/upload-artifact@v2.3.1
         with:
           name: aie-${{ steps.find-new-version.outputs.new_release_version }}.dmg.blockmap.zip
           path: dist/aie-${{ steps.find-new-version.outputs.new_release_version }}.dmg.blockmap
+      - name: Upload Packaged App (ARM64, untested)
+        uses: actions/upload-artifact@v2.3.1
+        with:
+          name: aie-${{ steps.find-new-version.outputs.new_release_version }}-arm64-untested.dmg.zip
+          path: dist/aie-${{ steps.find-new-version.outputs.new_release_version }}-arm64.dmg
+      - name: Upload Packaged Zip
+        uses: actions/upload-artifact@v2.3.1
+        with:
+          name: aie-${{ steps.find-new-version.outputs.new_release_version }}-arm64-untested-mac.zip.zip
+          path: dist/aie-${{ steps.find-new-version.outputs.new_release_version }}-arm64-mac.zip
+      - name: Upload Blockmap
+        uses: actions/upload-artifact@v2.3.1
+        with:
+          name: aie-${{ steps.find-new-version.outputs.new_release_version }}-arm64-untested.dmg.blockmap.zip
+          path: dist/aie-${{ steps.find-new-version.outputs.new_release_version }}-arm64.dmg.blockmap
+      - name: Upload Packaged App (Universal, untested)
+        uses: actions/upload-artifact@v2.3.1
+        with:
+          name: aie-${{ steps.find-new-version.outputs.new_release_version }}-universal-untested.dmg.zip
+          path: dist/aie-${{ steps.find-new-version.outputs.new_release_version }}-universal.dmg
+      - name: Upload Packaged Zip (Universal, untested)
+        uses: actions/upload-artifact@v2.3.1
+        with:
+          name: aie-${{ steps.find-new-version.outputs.new_release_version }}-universal-untested-mac.zip.zip
+          path: dist/aie-${{ steps.find-new-version.outputs.new_release_version }}-universal-mac.zip
+      - name: Upload Blockmap (Universal, untested)
+        uses: actions/upload-artifact@v2.3.1
+        with:
+          name: aie-${{ steps.find-new-version.outputs.new_release_version }}-universal-untested.dmg.blockmap.zip
+          path: dist/aie-${{ steps.find-new-version.outputs.new_release_version }}-universal.dmg.blockmap
       - name: Upload AutoUpdate Metadata
         uses: actions/upload-artifact@v2.3.1
         with:

--- a/electron-builder.js
+++ b/electron-builder.js
@@ -11,7 +11,7 @@ console.info(`Compression level: ${compression}`);
 
 module.exports = {
   appId: 'com.team-aie.app',
-  copyright: 'Copyright © 2020 ${author}',
+  copyright: 'Copyright © 2022 ${author}',
   asar: true,
   compression,
   files: [
@@ -26,8 +26,24 @@ module.exports = {
         arch: 'x64',
       },
       {
+        target: 'dmg',
+        arch: 'arm64',
+      },
+      {
+        target: 'dmg',
+        arch: 'universal',
+      },
+      {
         target: 'zip',
         arch: 'x64',
+      },
+      {
+        target: 'zip',
+        arch: 'arm64',
+      },
+      {
+        target: 'zip',
+        arch: 'universal',
       },
     ],
   },


### PR DESCRIPTION
This PR will use the latest `electron-builder` feature that builds for ARM64 and Universal macOS archs. However, I currently do not have devices to test with, so these builds are untested.